### PR TITLE
Fix SSL certificate verification and add LOCAL_DEV mode

### DIFF
--- a/docker.env.example
+++ b/docker.env.example
@@ -1,0 +1,36 @@
+# Example Environment Configuration for MADI Data Portal
+# Copy this file to docker.env and fill in your values
+
+# === Database Configuration ===
+DB_HOST=your-database-host
+DB_PORT=5432
+DB_NAME=your-database-name
+DB_USER=your-db-user
+DB_PASSWORD=your-db-password
+
+# === Dex OIDC Authentication ===
+# Your Dex server URL (must include https:// or http://)
+DEX_ISSUER=https://dex.dartmouth.edu
+
+# OAuth client credentials (get from Dex admin)
+DEX_CLIENT_ID=your-client-id
+DEX_CLIENT_SECRET=your-client-secret
+
+# Optional: Logout endpoint (usually auto-discovered)
+DEX_LOGOUT_ENDPOINT=
+
+# Optional: Custom CA certificate for SSL verification
+# Only needed if you get SSL verification errors
+# For Dartmouth's InCommon-signed Dex, provide the InCommon CA bundle
+# For self-signed certificates, provide the self-signed cert
+# Leave empty if using widely-trusted certificates (Let's Encrypt, DigiCert, etc.)
+DEX_CA_CERT_PATH=
+
+# Optional: Application redirect URI
+# Usually auto-detected, but can override if needed
+HOSTNAME=http://localhost:3838
+
+# === Development Mode ===
+# Set to 1 to bypass authentication with dummy user (dev only!)
+# Set to 0 or remove for production
+LOCAL_DEV=0

--- a/madi-shiny-front/app.R
+++ b/madi-shiny-front/app.R
@@ -457,6 +457,9 @@ server <- function(input, output, session) {
 
   exchange_code_for_token <- function(auth_code) {
     message("Attempting token exchange...")
+    message("🔍 [SSL DEBUG] Token endpoint: ", DEX_TOKEN_ENDPOINT)
+    message("🔍 [SSL DEBUG] CA cert path: ", if(!is.null(DEX_CA_CERT_PATH) && nzchar(DEX_CA_CERT_PATH)) DEX_CA_CERT_PATH else "(not set)")
+    
     tryCatch({
       token_req <- httr2::request(DEX_TOKEN_ENDPOINT) |>
         httr2::req_method("POST") |>
@@ -474,10 +477,14 @@ server <- function(input, output, session) {
       
       # Add custom CA certificate if provided
       if (!is.null(DEX_CA_CERT_PATH) && nzchar(DEX_CA_CERT_PATH) && file.exists(DEX_CA_CERT_PATH)) {
+        message("✅ [SSL DEBUG] Adding CA cert to token request: ", DEX_CA_CERT_PATH)
         token_req <- token_req |> httr2::req_options(cainfo = DEX_CA_CERT_PATH)
+      } else {
+        message("ℹ️  [SSL DEBUG] No custom CA cert for token exchange - using system defaults")
       }
       
       resp <- httr2::req_perform(token_req)
+      message("✅ [SSL DEBUG] Token exchange successful!")
       token_data <- httr2::resp_body_json(resp)
       if (is.null(token_data$id_token)) stop("No id_token received from token endpoint.")
       validated_payload <- validate_id_token(token_data$id_token)

--- a/madi-shiny-front/auth_config.R
+++ b/madi-shiny-front/auth_config.R
@@ -8,10 +8,14 @@ if (!require(jsonlite)) install.packages("jsonlite")
 `%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
 
 # --- Configuration (Load from Environment Variables or Secure Source) ---
+# Check if we're in local dev mode
+IS_LOCAL_DEV <- Sys.getenv("LOCAL_DEV", unset = "0") == "1"
+
 DEX_ISSUER <- Sys.getenv("DEX_ISSUER")
 DEX_CLIENT_ID <- Sys.getenv("DEX_CLIENT_ID")
 DEX_CLIENT_SECRET <- Sys.getenv("DEX_CLIENT_SECRET")
 DEX_LOGOUT_ENDPOINT <- Sys.getenv("DEX_LOGOUT_ENDPOINT")
+DEX_CA_CERT_PATH <- Sys.getenv("DEX_CA_CERT_PATH", unset = "")
 
 # === CRITICAL FIX: Redirect URI Configuration ===
 # Determine the correct redirect URI based on environment
@@ -35,38 +39,66 @@ determine_redirect_uri <- function() {
 APP_REDIRECT_URI <- determine_redirect_uri()
 
 # --- Fetch OIDC Discovery Information ---
-get_oidc_discovery <- function(issuer_url) {
+get_oidc_discovery <- function(issuer_url, ca_cert_path = NULL) {
   discovery_url <- paste0(issuer_url, "/.well-known/openid-configuration")
+  
   tryCatch({
-    resp <- httr2::request(discovery_url) |> # Use httr2:: explicitly if not loading here
+    req <- httr2::request(discovery_url)
+    
+    # Add custom CA certificate if provided
+    if (!is.null(ca_cert_path) && nzchar(ca_cert_path) && file.exists(ca_cert_path)) {
+      cat("Using custom CA certificate:", ca_cert_path, "\n")
+      req <- req |> httr2::req_options(cainfo = ca_cert_path)
+    }
+    
+    resp <- req |>
       httr2::req_perform() |>
       httr2::resp_body_json()
+      
     return(resp)
+    
   }, error = function(e) {
     warning(paste("Failed to fetch OIDC discovery document from:", discovery_url, "\nError:", e$message))
     return(NULL)
   })
 }
 
-oidc_config <- get_oidc_discovery(DEX_ISSUER)
+# Skip OIDC discovery and configuration in local dev mode
+if (IS_LOCAL_DEV) {
+  cat("⚠️  LOCAL_DEV mode enabled - Skipping OIDC configuration\n")
+  cat("Authentication will be bypassed with dummy user credentials\n")
+  
+  # Set dummy values to prevent errors
+  oidc_config <- NULL
+  DEX_AUTH_ENDPOINT <- NULL
+  DEX_TOKEN_ENDPOINT <- NULL
+  DEX_JWKS_ENDPOINT <- NULL
+  DEX_USERINFO_ENDPOINT <- NULL
+  dex_client <- NULL
+  OIDC_SCOPES <- "openid profile email"
+  
+} else {
+  # Production mode - perform normal OIDC discovery
+  oidc_config <- get_oidc_discovery(DEX_ISSUER, DEX_CA_CERT_PATH)
 
-# Extract endpoints
-DEX_AUTH_ENDPOINT <- oidc_config$authorization_endpoint %||% DEX_AUTH_ENDPOINT
-DEX_TOKEN_ENDPOINT <- oidc_config$token_endpoint %||% DEX_TOKEN_ENDPOINT
-DEX_JWKS_ENDPOINT <- oidc_config$jwks_uri %||% DEX_JWKS_ENDPOINT
-DEX_USERINFO_ENDPOINT <- oidc_config$userinfo_endpoint
-DEX_LOGOUT_ENDPOINT <- oidc_config$end_session_endpoint %||% DEX_LOGOUT_ENDPOINT
+  # Extract endpoints
+  DEX_AUTH_ENDPOINT <- oidc_config$authorization_endpoint %||% DEX_AUTH_ENDPOINT
+  DEX_TOKEN_ENDPOINT <- oidc_config$token_endpoint %||% DEX_TOKEN_ENDPOINT
+  DEX_JWKS_ENDPOINT <- oidc_config$jwks_uri %||% DEX_JWKS_ENDPOINT
+  DEX_USERINFO_ENDPOINT <- oidc_config$userinfo_endpoint
+  DEX_LOGOUT_ENDPOINT <- oidc_config$end_session_endpoint %||% DEX_LOGOUT_ENDPOINT
 
-# --- Create httr2 OAuth Client ---
-dex_client <- httr2::oauth_client( # Use httr2:: explicitly if not loading here
-  id = DEX_CLIENT_ID,
-  secret = DEX_CLIENT_SECRET,
-  token_url = DEX_TOKEN_ENDPOINT,
-  name = "MADILumiReaderLocalClient"
-)
+  # --- Create httr2 OAuth Client ---
+  dex_client <- httr2::oauth_client( # Use httr2:: explicitly if not loading here
+    id = DEX_CLIENT_ID,
+    secret = DEX_CLIENT_SECRET,
+    token_url = DEX_TOKEN_ENDPOINT,
+    name = "MADILumiReaderLocalClient"
+  )
 
-# --- Define Scopes ---
-OIDC_SCOPES <- "openid profile email"
+  # --- Define Scopes ---
+  OIDC_SCOPES <- "openid profile email"
+}
 
 # --- JWKS Cache ---
 jwks_cache <- NULL
@@ -74,11 +106,17 @@ jwks_cache_time <- NULL
 JWKS_CACHE_EXPIRY_SECS <- 5
 
 # Function to fetch JWKS (JSON Web Key Set) for token validation
-get_jwks <- function(jwks_url) {
+get_jwks <- function(jwks_url, ca_cert_path = NULL) {
   tryCatch({
-    response <- httr2::request(jwks_url) |>
-      httr2::req_timeout(10) |>
-      httr2::req_perform()
+    req <- httr2::request(jwks_url) |>
+      httr2::req_timeout(10)
+    
+    # Add custom CA certificate if provided
+    if (!is.null(ca_cert_path) && nzchar(ca_cert_path) && file.exists(ca_cert_path)) {
+      req <- req |> httr2::req_options(cainfo = ca_cert_path)
+    }
+    
+    response <- req |> httr2::req_perform()
     
     jwks_data <- httr2::resp_body_json(response)
     return(jwks_data$keys)
@@ -89,13 +127,19 @@ get_jwks <- function(jwks_url) {
 }
 
 # Test OIDC discovery document (optional but helpful for debugging)
-test_oidc_discovery <- function() {
+test_oidc_discovery <- function(ca_cert_path = NULL) {
   discovery_url <- paste0(DEX_ISSUER, "/.well-known/openid-configuration")
   
   tryCatch({
-    response <- httr2::request(discovery_url) |>
-      httr2::req_timeout(10) |>
-      httr2::req_perform()
+    req <- httr2::request(discovery_url) |>
+      httr2::req_timeout(10)
+    
+    # Add custom CA certificate if provided
+    if (!is.null(ca_cert_path) && nzchar(ca_cert_path) && file.exists(ca_cert_path)) {
+      req <- req |> httr2::req_options(cainfo = ca_cert_path)
+    }
+    
+    response <- req |> httr2::req_perform()
     
     discovery_data <- httr2::resp_body_json(response)
     
@@ -111,22 +155,24 @@ test_oidc_discovery <- function() {
   })
 }
 
-# Test the discovery endpoint
-cat("Testing OIDC discovery...\n")
-discovery_success <- test_oidc_discovery()
+# Test the discovery endpoint (skip in dev mode)
+if (!IS_LOCAL_DEV) {
+  cat("Testing OIDC discovery...\n")
+  discovery_success <- test_oidc_discovery(DEX_CA_CERT_PATH)
 
-if (discovery_success) {
-  cat("✅ Authentication configuration loaded successfully.\n")
-} else {
-  cat("⚠️ Authentication configuration loaded with warnings.\n")
+  if (discovery_success) {
+    cat("✅ Authentication configuration loaded successfully.\n")
+  } else {
+    cat("⚠️ Authentication configuration loaded with warnings.\n")
+  }
+
+  # Print configuration for debugging
+  cat("=== OIDC Configuration ===\n")
+  cat("DEX_ISSUER:", DEX_ISSUER, "\n")
+  cat("DEX_CLIENT_ID:", DEX_CLIENT_ID, "\n")
+  cat("APP_REDIRECT_URI:", APP_REDIRECT_URI, "\n")
+  cat("OIDC_SCOPES:", OIDC_SCOPES, "\n")
+  cat("===========================\n")
 }
-
-# Print configuration for debugging
-cat("=== OIDC Configuration ===\n")
-cat("DEX_ISSUER:", DEX_ISSUER, "\n")
-cat("DEX_CLIENT_ID:", DEX_CLIENT_ID, "\n")
-cat("APP_REDIRECT_URI:", APP_REDIRECT_URI, "\n")
-cat("OIDC_SCOPES:", OIDC_SCOPES, "\n")
-cat("===========================\n")
 
 cat("Authentication configuration loaded.\n")


### PR DESCRIPTION
## Changes

### 1. SSL Certificate Support
- Add `DEX_CA_CERT_PATH` environment variable to support custom CA certificates
- Update all HTTPS requests to Dex endpoints to accept optional CA cert path
- Fixes connection issues with InCommon-signed certificates and self-signed certs

### 2. Local Development Mode
- Add `LOCAL_DEV` environment variable to bypass OIDC authentication in dev mode
- Prevents errors when Dex endpoints are not configured
- Useful for local testing without authentication

### 3. Debug Logging
- Add comprehensive SSL debug logging to verify certificate handling
- Shows which CA bundle is being used (custom vs system defaults)
- Helps troubleshoot SSL/certificate issues

## Testing
✅ Successfully tested with Dartmouth Dex (InCommon certificate)
✅ OIDC discovery working without SSL errors
✅ Debug logging confirms SSL logic paths

## Configuration

### Production (with Dex)
```bash
DEX_ISSUER=https://your-dex-server.dartmouth.edu
DEX_CLIENT_ID=your-client-id
DEX_CLIENT_SECRET=your-client-secret
DEX_CA_CERT_PATH=  # Leave empty for trusted CAs, provide path for self-signed
LOCAL_DEV=0